### PR TITLE
Added status field

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTITUTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -26,6 +27,7 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + PREFIX_INSTITUTION + "INSTITUTION "
+            + "[" + PREFIX_STATUS + "STATUS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
@@ -33,6 +35,7 @@ public class AddCommand extends Command {
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_INSTITUTION + "NTU "
+            + PREFIX_STATUS + "INTERVIEWED "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTITUTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -21,6 +22,7 @@ import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Institution;
 import seedu.address.model.person.Name;
@@ -43,6 +45,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_STATUS + "STATUS] "
             + "[" + PREFIX_INSTITUTION + "INSTITUTION] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
@@ -101,9 +104,12 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Institution updatedInstitution = editPersonDescriptor.getInstitution().orElse(personToEdit.getInstitution());
+        ApplicationStatus updatedStatus = editPersonDescriptor.getApplicationStatus()
+                .orElse(personToEdit.getApplicationStatus());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedInstitution, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedInstitution,
+                updatedStatus, updatedTags);
     }
 
     @Override
@@ -134,6 +140,7 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private Institution institution;
+        private ApplicationStatus status;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -148,6 +155,7 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setInstitution(toCopy.institution);
+            setApplicationStatus(toCopy.status);
             setTags(toCopy.tags);
         }
 
@@ -155,7 +163,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, institution, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, institution, status, tags);
         }
 
         public void setName(Name name) {
@@ -198,6 +206,14 @@ public class EditCommand extends Command {
             return Optional.ofNullable(institution);
         }
 
+        public void setApplicationStatus(ApplicationStatus status) {
+            this.status = status;
+        }
+
+        public Optional<ApplicationStatus> getApplicationStatus() {
+            return Optional.ofNullable(status);
+        }
+
         /**
          * Sets {@code tags} to this object's {@code tags}.
          * A defensive copy of {@code tags} is used internally.
@@ -235,6 +251,7 @@ public class EditCommand extends Command {
                     && getEmail().equals(e.getEmail())
                     && getAddress().equals(e.getAddress())
                     && getInstitution().equals(e.getInstitution())
+                    && getApplicationStatus().equals(e.getApplicationStatus())
                     && getTags().equals(e.getTags());
         }
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -113,7 +113,7 @@ public class EditCommand extends Command {
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(updatedName, updatedPhone, updatedEmail,
-                updatedAddress, updatedGrade,  updatedInstitution, updatedStatus, updatedTags);
+                updatedAddress, updatedGrade, updatedInstitution, updatedStatus, updatedTags);
     }
 
     @Override
@@ -173,7 +173,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, grade, institution, status,tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, grade, institution, status, tags);
         }
 
         public void setName(Name name) {

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTITUTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -14,6 +15,7 @@ import java.util.stream.Stream;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Institution;
 import seedu.address.model.person.Name;
@@ -33,8 +35,8 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args,
-                        PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_INSTITUTION);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_TAG, PREFIX_INSTITUTION, PREFIX_STATUS);
 
         if (!arePrefixesPresent(argMultimap,
                 PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_INSTITUTION)
@@ -49,7 +51,14 @@ public class AddCommandParser implements Parser<AddCommand> {
         Institution institution = ParserUtil.parseInstitution(argMultimap.getValue(PREFIX_INSTITUTION).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, institution, tagList);
+        Person person;
+
+        if (argMultimap.getValue(PREFIX_STATUS).isEmpty()) {
+            person = new Person(name, phone, email, address, institution, tagList);
+        } else {
+            ApplicationStatus status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
+            person = new Person(name, phone, email, address, institution, status, tagList);
+        }
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -66,6 +66,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Institution institution = ParserUtil.parseInstitution(argMultimap.getValue(PREFIX_INSTITUTION).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
+        Person person;
         if (argMultimap.getValue(PREFIX_STATUS).isEmpty()) {
             person = new Person(name, phone, email, address, grade, institution, tagList);
         } else {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -9,8 +9,9 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
+    public static final Prefix PREFIX_ADDRESS = new Prefix("addr/");
     public static final Prefix PREFIX_INSTITUTION = new Prefix("i/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_STATUS = new Prefix("a/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -37,15 +37,15 @@ public class EditCommandParser implements Parser<EditCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                         PREFIX_STATUS, PREFIX_TAG, PREFIX_INSTITUTION);
-                ArgumentTokenizer.tokenize(args,
-                        PREFIX_NAME,
-                        PREFIX_PHONE,
-                        PREFIX_EMAIL,
-                        PREFIX_ADDRESS,
-                        PREFIX_TAG,
-                        PREFIX_GRADE,
-                        PREFIX_INSTITUTION
-                        PREFIX_STATUS);
+        ArgumentTokenizer.tokenize(args,
+                PREFIX_NAME,
+                PREFIX_PHONE,
+                PREFIX_EMAIL,
+                PREFIX_ADDRESS,
+                PREFIX_TAG,
+                PREFIX_GRADE,
+                PREFIX_INSTITUTION,
+                PREFIX_STATUS);
 
 
         Index index;

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -35,7 +35,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_GRADE,
                         PREFIX_STATUS, PREFIX_TAG, PREFIX_INSTITUTION);
         ArgumentTokenizer.tokenize(args,
                 PREFIX_NAME,

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTITUTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -33,8 +34,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args,
-                        PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_INSTITUTION);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_STATUS, PREFIX_TAG, PREFIX_INSTITUTION);
 
         Index index;
 
@@ -60,6 +61,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_INSTITUTION).isPresent()) {
             editPersonDescriptor
                     .setInstitution(ParserUtil.parseInstitution(argMultimap.getValue(PREFIX_INSTITUTION).get()));
+        }
+        if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
+            editPersonDescriptor
+                    .setApplicationStatus(ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Institution;
 import seedu.address.model.person.Name;
@@ -109,6 +110,21 @@ public class ParserUtil {
             throw new ParseException(Institution.MESSAGE_CONSTRAINTS);
         }
         return new Institution(trimmedInstitution);
+    }
+
+    /**
+     * Parses a {@code String status} into an {@code ApplicationStatus}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code status} is invalid.
+     */
+    public static ApplicationStatus parseStatus(String status) throws ParseException {
+        requireNonNull(status);
+        String trimmedStatus = status.trim();
+        if (!ApplicationStatus.isValidStatus(trimmedStatus)) {
+            throw new ParseException(ApplicationStatus.MESSAGE_CONSTRAINTS);
+        }
+        return new ApplicationStatus(trimmedStatus);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/ApplicationStatus.java
+++ b/src/main/java/seedu/address/model/person/ApplicationStatus.java
@@ -1,0 +1,78 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's application status in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidStatus(String)}
+ */
+public class ApplicationStatus {
+    public enum Status {
+        APPLIED, RECEIVED, SCHEDULED, INTERVIEWED, OFFERED, ACCEPTED, REJECTED
+    }
+
+    public static final Status DEFAULT_STATUS = Status.APPLIED;
+
+    public static final String MESSAGE_CONSTRAINTS = "Status only supports the current statuses:"
+            + Status.APPLIED.name() + ", " + Status.RECEIVED.name() + ", " + Status.SCHEDULED.name() + ", "
+            + Status.INTERVIEWED.name() + ", " + Status.OFFERED.name() + ", " + Status.ACCEPTED.name() + ", "
+            + Status.REJECTED.name();
+    public static final String VALIDATION_REGEX = Status.APPLIED.name() + "|" + Status.RECEIVED.name() + "|"
+            + Status.SCHEDULED.name() + "|" + Status.INTERVIEWED.name() + "|" + Status.OFFERED.name() + "|"
+            + Status.ACCEPTED.name() + "|" + Status.REJECTED.name();
+    public final Status value;
+
+    /**
+     * Constructs a {@code ApplicationStatus}.
+     *
+     * @param status A valid status string.
+     */
+    public ApplicationStatus(String status) {
+        requireNonNull(status);
+        checkArgument(isValidStatus(status), MESSAGE_CONSTRAINTS);
+        value = Status.valueOf(status);
+    }
+
+    /**
+     * Constructs a {@code ApplicationStatus}.
+     *
+     * @param status A valid status.
+     */
+    public ApplicationStatus(Status status) {
+        requireNonNull(status);
+        value = status;
+    }
+
+    /**
+     * Constructs a {@code ApplicationStatus}.
+     */
+    public ApplicationStatus() {
+        value = DEFAULT_STATUS;
+    }
+
+    /**
+     * Returns true if a given string is a valid status.
+     */
+    public static boolean isValidStatus(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value.name();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ApplicationStatus // instanceof handles nulls
+                && value == ((ApplicationStatus) other).value); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -30,7 +30,8 @@ public class Person {
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Grade grade, Institution institution, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, Grade grade,
+                  Institution institution, Set<Tag> tags) {
         this(name, phone, email, address, grade, institution,
                 new ApplicationStatus(ApplicationStatus.DEFAULT_STATUS), tags);
     }
@@ -38,7 +39,7 @@ public class Person {
     /**
      * Overloaded constructor for creating candidates with default status
      */
-    public Person(Name name, Phone phone, Email email, Address address, Grade grade, 
+    public Person(Name name, Phone phone, Email email, Address address, Grade grade,
                   Institution institution, ApplicationStatus status, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, grade, status, institution, tags);
         this.name = name;

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -24,17 +24,28 @@ public class Person {
     private final Institution institution;
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final ApplicationStatus status;
 
     /**
      * Every field must be present and not null.
      */
     public Person(Name name, Phone phone, Email email, Address address, Institution institution, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, institution, tags);
+        this(name, phone, email, address, institution,
+                new ApplicationStatus(ApplicationStatus.DEFAULT_STATUS), tags);
+    }
+
+    /**
+     * Overloaded constructor for creating candidates with default status
+     */
+    public Person(Name name, Phone phone, Email email, Address address, Institution institution,
+                  ApplicationStatus status, Set<Tag> tags) {
+        requireAllNonNull(name, phone, email, address, institution, status, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.institution = institution;
+        this.status = status;
         this.tags.addAll(tags);
     }
 
@@ -56,6 +67,10 @@ public class Person {
 
     public Address getAddress() {
         return address;
+    }
+
+    public ApplicationStatus getApplicationStatus() {
+        return status;
     }
 
     /**
@@ -99,19 +114,22 @@ public class Person {
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getAddress().equals(getAddress())
                 && otherPerson.getInstitution().equals(getInstitution())
+                && otherPerson.getApplicationStatus().equals(getApplicationStatus())
                 && otherPerson.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, institution, tags);
+        return Objects.hash(name, phone, email, address, institution, status, tags);
     }
 
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
         builder.append(getName())
+                .append("; Status: ")
+                .append(getApplicationStatus())
                 .append("; Phone: ")
                 .append(getPhone())
                 .append("; Email: ")

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -143,8 +143,8 @@ class JsonAdaptedPerson {
         }
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-      
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, 
+
+        return new Person(modelName, modelPhone, modelEmail, modelAddress,
                           modelGrade, modelInstitution, modelStatus, modelTags);
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Institution;
 import seedu.address.model.person.Name;
@@ -30,6 +31,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final String institution;
+    private final String status;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
@@ -38,12 +40,14 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("institution") String institution, @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+            @JsonProperty("institution") String institution, @JsonProperty("status") String status,
+            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.institution = institution;
+        this.status = status;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -58,6 +62,7 @@ class JsonAdaptedPerson {
         email = source.getEmail().value;
         address = source.getAddress().value;
         institution = source.getInstitution().value;
+        status = source.getApplicationStatus().value.toString();
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -115,8 +120,18 @@ class JsonAdaptedPerson {
         }
         final Institution modelInstitution = new Institution(institution);
 
+        final ApplicationStatus modelStatus;
+
+        if (status == null) {
+            modelStatus = new ApplicationStatus();
+        } else if (!ApplicationStatus.isValidStatus(status)) {
+            throw new IllegalValueException(ApplicationStatus.MESSAGE_CONSTRAINTS);
+        } else {
+            modelStatus = new ApplicationStatus(status);
+        }
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelInstitution, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelInstitution, modelStatus, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -41,6 +41,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label institution;
     @FXML
+    private Label status;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -54,7 +56,9 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
+        status.setText(person.getApplicationStatus().value.toString());
         institution.setText(person.getInstitution().value);
+
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -31,6 +31,7 @@
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="institution" styleClass="cell_small_label" text="\$institution" />
+      <Label fx:id="status" styleClass="cell_small_label" text="\$status" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
   </GridPane>

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -49,8 +49,8 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, 
-                        VALID_GRADE,VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
 
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -67,7 +67,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, 
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                      VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
 
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
@@ -77,7 +77,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                null, VALID_EMAIL, VALID_ADDRESS,  VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
+                null, VALID_EMAIL, VALID_ADDRESS, VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,7 +86,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
+                        VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_GRADE, VALID_INSTITUTION,
+                        VALID_STATUS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -94,7 +95,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                VALID_PHONE, null, VALID_ADDRESS,  VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
+                VALID_PHONE, null, VALID_ADDRESS, VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
 
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -104,7 +105,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
+                        VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_GRADE, VALID_INSTITUTION,
+                        VALID_STATUS, VALID_TAGS);
 
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -124,7 +126,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidGrade_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_GRADE, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
+                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_GRADE, VALID_INSTITUTION,
+                        VALID_STATUS, VALID_TAGS);
         String expectedMessage = Grade.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -139,9 +142,8 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidInstitution_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,  VALID_GRADE,INVALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_GRADE, INVALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
 
         String expectedMessage = Institution.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
@@ -157,8 +159,8 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidStatus_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_GRADE, VALID_INSTITUTION, INVALID_STATUS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_GRADE, VALID_INSTITUTION, INVALID_STATUS, VALID_TAGS);
         String expectedMessage = ApplicationStatus.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -167,8 +169,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, invalidTags);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_GRADE, VALID_INSTITUTION, VALID_STATUS, invalidTags);
 
         assertThrows(IllegalValueException.class, person::toModelType);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.ApplicationStatus;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Institution;
 import seedu.address.model.person.Name;
@@ -25,12 +26,14 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_INSTITUTION = "NU$@";
+    private static final String INVALID_STATUS = "OOP";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final String VALID_INSTITUTION = BENSON.getInstitution().toString();
+    private static final String VALID_STATUS = BENSON.getApplicationStatus().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -43,8 +46,8 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(INVALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -52,7 +55,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null,
-                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_TAGS);
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -61,7 +64,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME,
-                        INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_TAGS);
+                        INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -69,7 +72,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                null, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_TAGS);
+                null, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -78,7 +81,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_TAGS);
+                        VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,7 +89,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                VALID_PHONE, null, VALID_ADDRESS, VALID_INSTITUTION, VALID_TAGS);
+                VALID_PHONE, null, VALID_ADDRESS, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -95,7 +98,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_INSTITUTION, VALID_TAGS);
+                        VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,7 +106,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                VALID_PHONE, VALID_EMAIL, null, VALID_INSTITUTION, VALID_TAGS);
+                VALID_PHONE, VALID_EMAIL, null, VALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -112,7 +115,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidInstitution_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_INSTITUTION, VALID_TAGS);
+                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, INVALID_INSTITUTION, VALID_STATUS, VALID_TAGS);
         String expectedMessage = Institution.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -120,8 +123,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullInstitution_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
-                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, null, VALID_TAGS);
+                VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, null, VALID_STATUS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Institution.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidStatus_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
+                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, INVALID_STATUS, VALID_TAGS);
+        String expectedMessage = ApplicationStatus.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -129,9 +140,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME,
-                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, invalidTags);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME,
+                        VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_INSTITUTION, VALID_STATUS, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -118,6 +118,4 @@ public class PersonBuilder {
     public Person build() {
         return new Person(name, phone, email, address, grade, institution, tags);
     }
-
-
 }


### PR DESCRIPTION
- Changed address prefix to /addr, pending approval for removal
- Added a/ prefix with json "status" for application status
- Application status defaults to Status.APPLIED, with overloaded constructor to specify statuses

This PR can be referenced for:
1. Fields with an ENUM type
2. Fields that are optional

#10 