### PR TITLE
Add editAll feature

### DIFF
--- a/src/main/java/seedu/intern/logic/commands/EditAllCommand.java
+++ b/src/main/java/seedu/intern/logic/commands/EditAllCommand.java
@@ -2,7 +2,6 @@ package seedu.intern.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.intern.logic.parser.CliSyntax.PREFIX_STATUS;
-import static seedu.intern.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,10 +32,12 @@ public class EditAllCommand extends Command {
             + "provided fields."
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: "
-            + "[" + PREFIX_STATUS + "STATUS]\n";
+            + "[" + PREFIX_STATUS + "STATUS]\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_STATUS + "INTERVIEWED";
 
     // TODO: update this message
-    public static final String MESSAGE_EDIT_ALL_SUCCESS = "Edited currently displayed applicants: ";
+    public static final String MESSAGE_EDIT_ALL_SUCCESS = "Successfully edited %d of %d applicants.\n";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.\n";
 
     private final EditAllDescriptor editAllDescriptor;
@@ -61,10 +62,7 @@ public class EditAllCommand extends Command {
             addSuccesses++;
         }
 
-        String result = addSuccesses + " of " + lastShownList.size() + " applicants updated\n";
-
-        model.updateFilteredApplicantList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_ALL_SUCCESS, result));
+        return new CommandResult(String.format(MESSAGE_EDIT_ALL_SUCCESS, addSuccesses, lastShownList.size()));
     }
 
     /**

--- a/src/main/java/seedu/intern/logic/commands/EditAllCommand.java
+++ b/src/main/java/seedu/intern/logic/commands/EditAllCommand.java
@@ -33,8 +33,8 @@ public class EditAllCommand extends Command {
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: "
             + "[" + PREFIX_STATUS + "STATUS]\n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_STATUS + "INTERVIEWED";
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_STATUS + " INTERVIEWED";
 
     // TODO: update this message
     public static final String MESSAGE_EDIT_ALL_SUCCESS = "Successfully edited %d of %d applicants.\n";
@@ -82,6 +82,7 @@ public class EditAllCommand extends Command {
         Course updatedCourse = applicantToEdit.getCourse();
         Set<Skill> updatedSkills = applicantToEdit.getSkills();
 
+        // Fields editable by editAllCommand
         ApplicationStatus updatedStatus = editAllDescriptor.getApplicationStatus()
                 .orElse(applicantToEdit.getApplicationStatus());
 

--- a/src/main/java/seedu/intern/logic/commands/EditAllCommand.java
+++ b/src/main/java/seedu/intern/logic/commands/EditAllCommand.java
@@ -1,0 +1,171 @@
+package seedu.intern.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.intern.logic.parser.CliSyntax.PREFIX_STATUS;
+import static seedu.intern.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.intern.commons.util.CollectionUtil;
+import seedu.intern.logic.commands.exceptions.CommandException;
+import seedu.intern.model.Model;
+import seedu.intern.model.applicant.Applicant;
+import seedu.intern.model.applicant.ApplicationStatus;
+import seedu.intern.model.applicant.Course;
+import seedu.intern.model.applicant.Email;
+import seedu.intern.model.applicant.Grade;
+import seedu.intern.model.applicant.GraduationYearMonth;
+import seedu.intern.model.applicant.Institution;
+import seedu.intern.model.applicant.Name;
+import seedu.intern.model.applicant.Phone;
+import seedu.intern.model.skills.Skill;
+
+/**
+ * Edits the details of all currently displayed applicants in Intern Watcher.
+ */
+public class EditAllCommand extends Command {
+
+    public static final String COMMAND_WORD = "editAll";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Updates all currently displayed applicants with the"
+            + "provided fields."
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: "
+            + "[" + PREFIX_STATUS + "STATUS]\n";
+
+    // TODO: update this message
+    public static final String MESSAGE_EDIT_ALL_SUCCESS = "Edited currently displayed applicants: ";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.\n";
+
+    private final EditAllDescriptor editAllDescriptor;
+
+    /**
+     * @param editAllDescriptor details to update all applicants with
+     */
+    public EditAllCommand(EditAllDescriptor editAllDescriptor) {
+        this.editAllDescriptor = new EditAllDescriptor(editAllDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Applicant> lastShownList = model.getFilteredPersonList();
+        int addSuccesses = 0;
+
+        // TODO: Catch failures to update?
+        for (Applicant applicantToEdit : lastShownList) {
+            Applicant editedApplicant = createEditedApplicant(applicantToEdit, editAllDescriptor);
+            model.setApplicant(applicantToEdit, editedApplicant);
+            addSuccesses++;
+        }
+
+        String result = addSuccesses + " of " + lastShownList.size() + " applicants updated\n";
+
+        model.updateFilteredApplicantList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_ALL_SUCCESS, result));
+    }
+
+    /**
+     * Creates and returns a {@code Applicant} with the details of {@code applicantToEdit}
+     * edited with {@code EditAllDescriptor}.
+     */
+    private static Applicant createEditedApplicant(Applicant applicantToEdit,
+                                                EditAllDescriptor editAllDescriptor) {
+        assert applicantToEdit != null;
+
+        Name updatedName = applicantToEdit.getName();
+        Phone updatedPhone = applicantToEdit.getPhone();
+        Email updatedEmail = applicantToEdit.getEmail();
+        Grade updatedGrade = applicantToEdit.getGrade();
+        Institution updatedInstitution = applicantToEdit.getInstitution();
+        GraduationYearMonth updatedGraduationYearMonth = applicantToEdit.getGraduationYearMonth();
+        Course updatedCourse = applicantToEdit.getCourse();
+        Set<Skill> updatedSkills = applicantToEdit.getSkills();
+
+        ApplicationStatus updatedStatus = editAllDescriptor.getApplicationStatus()
+                .orElse(applicantToEdit.getApplicationStatus());
+
+        return new Applicant(updatedName, updatedPhone, updatedEmail,
+                updatedGrade, updatedInstitution, updatedCourse,
+                updatedGraduationYearMonth, updatedStatus, updatedSkills);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditAllCommand)) {
+            return false;
+        }
+
+        // state check
+        EditAllCommand e = (EditAllCommand) other;
+        return editAllDescriptor.equals(e.editAllDescriptor);
+    }
+
+    public String toString() {
+        return editAllDescriptor.toString();
+    }
+
+    /**
+     * Stores the details to update all applicants with. Each non-empty field value will replace the
+     * corresponding field value of all currently filtered applicants.
+     */
+    public static class EditAllDescriptor {
+        private ApplicationStatus status;
+
+        public EditAllDescriptor() {}
+
+        /**
+         * Copy constructor.
+         */
+        public EditAllDescriptor(EditAllDescriptor toCopy) {
+            setApplicationStatus(toCopy.status);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(status);
+        }
+
+        public void setApplicationStatus(ApplicationStatus status) {
+            this.status = status;
+        }
+
+        public Optional<ApplicationStatus> getApplicationStatus() {
+            return Optional.ofNullable(status);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditAllDescriptor)) {
+                return false;
+            }
+
+            // state check
+            EditAllDescriptor e = (EditAllDescriptor) other;
+
+            return getApplicationStatus().equals(e.getApplicationStatus());
+        }
+
+        @Override
+        public String toString() {
+            return "EditAllDescriptor{" + "status=" + status + '}';
+        }
+
+    }
+}

--- a/src/main/java/seedu/intern/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/intern/logic/commands/EditCommand.java
@@ -304,6 +304,7 @@ public class EditCommand extends Command {
                     + ", institution=" + institution
                     + ", graduation year month=" + graduationYearMonth
                     + ", course=" + course
+                    + ", status=" + status
                     + ", skill=" + skills + '}';
         }
 

--- a/src/main/java/seedu/intern/logic/parser/EditAllCommandParser.java
+++ b/src/main/java/seedu/intern/logic/parser/EditAllCommandParser.java
@@ -1,0 +1,38 @@
+package seedu.intern.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.intern.logic.parser.CliSyntax.PREFIX_STATUS;
+
+import seedu.intern.logic.commands.EditAllCommand;
+import seedu.intern.logic.commands.EditAllCommand.EditAllDescriptor;
+import seedu.intern.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditAllCommand object
+ */
+public class EditAllCommandParser implements Parser<EditAllCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditAllCommand
+     * and returns an EditAllCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     * @return
+     */
+    public EditAllCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_STATUS);
+        ArgumentTokenizer.tokenize(args, PREFIX_STATUS);
+
+        EditAllDescriptor editAllDescriptor = new EditAllDescriptor();
+
+        if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
+            editAllDescriptor
+                    .setApplicationStatus(ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get()));
+        }
+        if (!editAllDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditAllCommand.MESSAGE_NOT_EDITED + EditAllCommand.MESSAGE_USAGE);
+        }
+
+        return new EditAllCommand(editAllDescriptor);
+    }
+}

--- a/src/main/java/seedu/intern/logic/parser/EditAllCommandParser.java
+++ b/src/main/java/seedu/intern/logic/parser/EditAllCommandParser.java
@@ -15,7 +15,6 @@ public class EditAllCommandParser implements Parser<EditAllCommand> {
      * Parses the given {@code String} of arguments in the context of the EditAllCommand
      * and returns an EditAllCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
-     * @return
      */
     public EditAllCommand parse(String args) throws ParseException {
         requireNonNull(args);

--- a/src/main/java/seedu/intern/logic/parser/InternWatcherParser.java
+++ b/src/main/java/seedu/intern/logic/parser/InternWatcherParser.java
@@ -10,6 +10,7 @@ import seedu.intern.logic.commands.AddCommand;
 import seedu.intern.logic.commands.ClearCommand;
 import seedu.intern.logic.commands.Command;
 import seedu.intern.logic.commands.DeleteCommand;
+import seedu.intern.logic.commands.EditAllCommand;
 import seedu.intern.logic.commands.EditCommand;
 import seedu.intern.logic.commands.ExitCommand;
 import seedu.intern.logic.commands.FindCommand;
@@ -67,6 +68,9 @@ public class InternWatcherParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case EditAllCommand.COMMAND_WORD:
+            return new EditAllCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/test/data/JsonSerializableInternWatcherTest/typicalPersonsInternWatcher.json
+++ b/src/test/data/JsonSerializableInternWatcherTest/typicalPersonsInternWatcher.json
@@ -7,6 +7,7 @@
     "grade": "4.50",
     "institution": "NUS",
     "course": "Computer Science",
+    "status": "REJECTED",
     "graduationYearMonth" : "12/2020",
     "skills" : [ "friends" ]
   }, {
@@ -16,6 +17,7 @@
     "grade": "4.60",
     "institution": "NTU",
     "course": "Computer Engineering",
+    "status": "INTERVIEWED",
     "graduationYearMonth" : "06/2025",
     "skills" : [ "owesMoney", "friends" ]
   }, {
@@ -24,6 +26,7 @@
     "email" : "heinz@example.com",
     "grade": "4.70",
     "institution": "NTU",
+    "status": "ACCEPTED",
     "course": "Business and Accounting",
     "graduationYearMonth" : "12/2023",
     "skills" : [ ]

--- a/src/test/java/seedu/intern/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/intern/logic/commands/CommandTestUtil.java
@@ -10,6 +10,7 @@ import static seedu.intern.logic.parser.CliSyntax.PREFIX_INSTITUTION;
 import static seedu.intern.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.intern.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.intern.logic.parser.CliSyntax.PREFIX_SKILL;
+import static seedu.intern.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.intern.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ import seedu.intern.model.InternWatcher;
 import seedu.intern.model.Model;
 import seedu.intern.model.applicant.Applicant;
 import seedu.intern.model.applicant.NameContainsKeywordsPredicate;
+import seedu.intern.testutil.EditAllDescriptorBuilder;
 import seedu.intern.testutil.EditApplicantDescriptorBuilder;
 
 /**
@@ -37,6 +39,8 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_GRADE_AMY = "4.50";
     public static final String VALID_GRADE_BOB = "4.60";
+    public static final String VALID_STATUS_AMY = "INTERVIEWED";
+    public static final String VALID_STATUS_BOB = "REJECTED";
     public static final String VALID_INSTITUTION_AMY = "NUS";
     public static final String VALID_INSTITUTION_BOB = "NUSS";
     @SuppressWarnings("SpellCheckingInspection")
@@ -64,6 +68,8 @@ public class CommandTestUtil {
     @SuppressWarnings("SpellCheckingInspection")
     public static final String GRADUATION_YEARMONTH_DESC_BOB = " "
             + PREFIX_GRADUATIONYEARMONTH + VALID_GRADUATION_YEARMONTH_BOB;
+    public static final String STATUS_DESC_AMY = " " + PREFIX_STATUS + VALID_STATUS_AMY;
+    public static final String STATUS_DESC_BOB = " " + PREFIX_STATUS + VALID_STATUS_BOB;
     public static final String COURSE_DESC_AMY = " " + PREFIX_COURSE + VALID_COURSE_AMY;
     public static final String COURSE_DESC_BOB = " " + PREFIX_COURSE + VALID_COURSE_BOB;
     public static final String SKILL_DESC_PYTHON = " " + PREFIX_SKILL + VALID_SKILL_PYTHON;
@@ -75,6 +81,7 @@ public class CommandTestUtil {
     public static final String INVALID_GRADE_DESC = " " + PREFIX_GRADE + "5.000"; //3dp not allowed for grades
     public static final String INVALID_SKILL_DESC = " " + PREFIX_SKILL + "java*"; // '*' not allowed in SKILLs
     public static final String INVALID_INSTITUTION_DESC = " " + PREFIX_INSTITUTION + "NU$"; // '$' not allowed
+    public static final String INVALID_STATUS_DESC = " " + PREFIX_STATUS + "somestring"; // value must be in enum
     @SuppressWarnings("SpellCheckingInspection")
     public static final String INVALID_GRADUATION_YEARMONTH_DESC = " " + PREFIX_GRADUATIONYEARMONTH
             + "13/2021"; // invalid month not allowed
@@ -86,17 +93,21 @@ public class CommandTestUtil {
 
     public static final EditCommand.EditApplicantDescriptor DESC_AMY;
     public static final EditCommand.EditApplicantDescriptor DESC_BOB;
+    public static final EditAllCommand.EditAllDescriptor DESC_ALL_AMY;
+    public static final EditAllCommand.EditAllDescriptor DESC_ALL_BOB;
 
     static {
         DESC_AMY = new EditApplicantDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY)
+                .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withApplicationStatus(VALID_STATUS_AMY)
                 .withGrade(VALID_GRADE_AMY).withInstitution(VALID_INSTITUTION_AMY).withCourse(VALID_COURSE_AMY)
                 .withGraduationYearMonth(VALID_GRADUATION_YEARMONTH_AMY).withSkills(VALID_SKILL_PYTHON).build();
         DESC_BOB = new EditApplicantDescriptorBuilder().withName(VALID_NAME_BOB)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withApplicationStatus(VALID_STATUS_BOB)
                 .withGrade(VALID_GRADE_BOB).withInstitution(VALID_INSTITUTION_BOB).withCourse(VALID_COURSE_BOB)
                 .withGraduationYearMonth(VALID_GRADUATION_YEARMONTH_BOB)
                 .withSkills(VALID_SKILL_JAVA, VALID_SKILL_PYTHON).build();
+        DESC_ALL_AMY = new EditAllDescriptorBuilder().withApplicationStatus(VALID_STATUS_AMY).build();
+        DESC_ALL_BOB = new EditAllDescriptorBuilder().withApplicationStatus(VALID_STATUS_BOB).build();
     }
 
     /**

--- a/src/test/java/seedu/intern/logic/commands/EditAllCommandTest.java
+++ b/src/test/java/seedu/intern/logic/commands/EditAllCommandTest.java
@@ -1,26 +1,15 @@
 package seedu.intern.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.intern.logic.commands.CommandTestUtil.DESC_AMY;
-import static seedu.intern.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.DESC_ALL_AMY;
 import static seedu.intern.logic.commands.CommandTestUtil.DESC_ALL_BOB;
-import static seedu.intern.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_STATUS_AMY;
-import static seedu.intern.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.intern.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.intern.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.intern.testutil.TypicalApplicants.getTypicalInternWatcher;
-import static seedu.intern.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.intern.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.intern.commons.core.Messages;
-import seedu.intern.commons.core.index.Index;
 import seedu.intern.logic.commands.EditAllCommand.EditAllDescriptor;
 import seedu.intern.model.InternWatcher;
 import seedu.intern.model.Model;
@@ -29,7 +18,6 @@ import seedu.intern.model.UserPrefs;
 import seedu.intern.model.applicant.Applicant;
 import seedu.intern.testutil.ApplicantBuilder;
 import seedu.intern.testutil.EditAllDescriptorBuilder;
-import seedu.intern.testutil.EditApplicantDescriptorBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.

--- a/src/test/java/seedu/intern/logic/commands/EditAllCommandTest.java
+++ b/src/test/java/seedu/intern/logic/commands/EditAllCommandTest.java
@@ -1,0 +1,118 @@
+package seedu.intern.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.intern.logic.commands.CommandTestUtil.DESC_AMY;
+import static seedu.intern.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.intern.logic.commands.CommandTestUtil.DESC_ALL_AMY;
+import static seedu.intern.logic.commands.CommandTestUtil.DESC_ALL_BOB;
+import static seedu.intern.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.intern.logic.commands.CommandTestUtil.VALID_STATUS_AMY;
+import static seedu.intern.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.intern.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.intern.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.intern.testutil.TypicalApplicants.getTypicalInternWatcher;
+import static seedu.intern.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.intern.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.intern.commons.core.Messages;
+import seedu.intern.commons.core.index.Index;
+import seedu.intern.logic.commands.EditAllCommand.EditAllDescriptor;
+import seedu.intern.model.InternWatcher;
+import seedu.intern.model.Model;
+import seedu.intern.model.ModelManager;
+import seedu.intern.model.UserPrefs;
+import seedu.intern.model.applicant.Applicant;
+import seedu.intern.testutil.ApplicantBuilder;
+import seedu.intern.testutil.EditAllDescriptorBuilder;
+import seedu.intern.testutil.EditApplicantDescriptorBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
+ */
+public class EditAllCommandTest {
+
+    private Model model = new ModelManager(getTypicalInternWatcher(), new UserPrefs());
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Applicant editedApplicant = new ApplicantBuilder().build();
+        EditAllDescriptor descriptor = new EditAllDescriptorBuilder(editedApplicant).build();
+        EditAllCommand editAllCommand = new EditAllCommand(descriptor);
+
+        String expectedMessage = String.format(EditAllCommand.MESSAGE_EDIT_ALL_SUCCESS,
+                model.getFilteredPersonList().size(),
+                model.getFilteredPersonList().size());
+
+        Model expectedModel = new ModelManager(new InternWatcher(model.getInternWatcher()), new UserPrefs());
+        for (Applicant applicant : model.getFilteredPersonList()) {
+            Applicant editedCurrentApplicant = new ApplicantBuilder(applicant)
+                    .withApplicationStatus(editedApplicant.getApplicationStatus().toString()).build();
+            expectedModel.setApplicant(applicant, editedCurrentApplicant);
+        }
+
+
+        assertCommandSuccess(editAllCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() {
+        // edit all currently only has 1 field that can be edited, so this test is identical to the first.
+        EditAllDescriptor descriptor = new EditAllDescriptorBuilder().withApplicationStatus(VALID_STATUS_AMY).build();
+        EditAllCommand editAllCommand = new EditAllCommand(descriptor);
+
+        String expectedMessage = String.format(EditAllCommand.MESSAGE_EDIT_ALL_SUCCESS,
+                model.getFilteredPersonList().size(),
+                model.getFilteredPersonList().size());
+
+        Model expectedModel = new ModelManager(new InternWatcher(model.getInternWatcher()), new UserPrefs());
+        for (Applicant applicant : model.getFilteredPersonList()) {
+            Applicant editedCurrentApplicant = new ApplicantBuilder(applicant)
+                    .withApplicationStatus(VALID_STATUS_AMY).build();
+            expectedModel.setApplicant(applicant, editedCurrentApplicant);
+        }
+
+        assertCommandSuccess(editAllCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecifiedUnfilteredList_success() {
+        EditAllCommand editAllCommand = new EditAllCommand(new EditAllDescriptor());
+
+        String expectedMessage = String.format(EditAllCommand.MESSAGE_EDIT_ALL_SUCCESS,
+                model.getFilteredPersonList().size(),
+                model.getFilteredPersonList().size());
+
+        Model expectedModel = new ModelManager(new InternWatcher(model.getInternWatcher()), new UserPrefs());
+
+        assertCommandSuccess(editAllCommand, model, expectedMessage, expectedModel);
+    }
+    //TODO: Add filtered list success test
+
+    @Test
+    public void equals() {
+        final EditAllCommand standardCommand = new EditAllCommand(DESC_ALL_AMY);
+
+        // same values -> returns true
+        EditAllDescriptor copyDescriptor = new EditAllDescriptor(DESC_ALL_AMY);
+        EditAllCommand commandWithSameValues = new EditAllCommand(copyDescriptor);
+        assertEquals(commandWithSameValues, standardCommand);
+
+        // same object -> returns true
+        assertEquals(standardCommand, standardCommand);
+
+        // null -> returns false
+        assertNotEquals(standardCommand, null);
+
+        // different types -> returns false
+        assertNotEquals(new ClearCommand(), standardCommand);
+
+        // different descriptor -> returns false
+        assertNotEquals(new EditAllCommand(DESC_ALL_BOB), standardCommand);
+    }
+
+}

--- a/src/test/java/seedu/intern/logic/parser/EditAllCommandParserTest.java
+++ b/src/test/java/seedu/intern/logic/parser/EditAllCommandParserTest.java
@@ -1,0 +1,68 @@
+package seedu.intern.logic.parser;
+
+import static seedu.intern.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.intern.logic.commands.CommandTestUtil.INVALID_STATUS_DESC;
+import static seedu.intern.logic.commands.CommandTestUtil.STATUS_DESC_AMY;
+import static seedu.intern.logic.commands.CommandTestUtil.STATUS_DESC_BOB;
+import static seedu.intern.logic.commands.CommandTestUtil.VALID_STATUS_AMY;
+import static seedu.intern.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.intern.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.intern.logic.commands.EditAllCommand;
+import seedu.intern.logic.commands.EditAllCommand.EditAllDescriptor;
+import seedu.intern.model.applicant.ApplicationStatus;
+import seedu.intern.testutil.EditAllDescriptorBuilder;
+
+public class EditAllCommandParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditAllCommand.MESSAGE_USAGE);
+
+    private EditAllCommandParser parser = new EditAllCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no field specified
+        assertParseFailure(parser, "",
+                EditAllCommand.MESSAGE_NOT_EDITED + EditAllCommand.MESSAGE_USAGE);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, INVALID_STATUS_DESC , ApplicationStatus.MESSAGE_CONSTRAINTS); // invalid status
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        String userInput = STATUS_DESC_AMY;
+
+        EditAllDescriptor descriptor = new EditAllDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_AMY).build();
+        EditAllCommand expectedCommand = new EditAllCommand(descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() {
+        String userInput = STATUS_DESC_BOB + STATUS_DESC_AMY;
+
+        EditAllDescriptor descriptor = new EditAllDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_AMY).build();
+        EditAllCommand expectedCommand = new EditAllCommand(descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_invalidValueFollowedByValidValue_success() {
+        String userInput = INVALID_STATUS_DESC + STATUS_DESC_AMY;
+
+        EditAllDescriptor descriptor = new EditAllDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_AMY).build();
+        EditAllCommand expectedCommand = new EditAllCommand(descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/intern/testutil/ApplicantBuilder.java
+++ b/src/test/java/seedu/intern/testutil/ApplicantBuilder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.intern.model.applicant.Applicant;
+import seedu.intern.model.applicant.ApplicationStatus;
 import seedu.intern.model.applicant.Course;
 import seedu.intern.model.applicant.Email;
 import seedu.intern.model.applicant.Grade;
@@ -15,7 +16,7 @@ import seedu.intern.model.skills.Skill;
 import seedu.intern.model.util.SampleDataUtil;
 
 /**
- * A utility class to help with building Person objects.
+ * A utility class to help with building Applicant objects.
  */
 public class ApplicantBuilder {
 
@@ -32,13 +33,14 @@ public class ApplicantBuilder {
     private Phone phone;
     private Email email;
     private Grade grade;
+    private ApplicationStatus status;
     private Institution institution;
     private GraduationYearMonth graduationYearMonth;
     private Course course;
     private Set<Skill> skills;
 
     /**
-     * Creates a {@code PersonBuilder} with the default details.
+     * Creates a {@code ApplicantBuilder} with the default details.
      */
     public ApplicantBuilder() {
         name = new Name(DEFAULT_NAME);
@@ -47,12 +49,13 @@ public class ApplicantBuilder {
         grade = new Grade(DEFAULT_GRADE);
         institution = new Institution(DEFAULT_INSTITUTION);
         graduationYearMonth = new GraduationYearMonth(DEFAULT_GRADUATIONYEARMONTH);
+        status = new ApplicationStatus(ApplicationStatus.DEFAULT_STATUS);
         course = new Course(DEFAULT_COURSE);
         skills = new HashSet<>();
     }
 
     /**
-     * Initializes the PersonBuilder with the data of {@code personToCopy}.
+     * Initializes the ApplicantBuilder with the data of {@code ApplicantToCopy}.
      */
     public ApplicantBuilder(Applicant applicantToCopy) {
         name = applicantToCopy.getName();
@@ -62,11 +65,12 @@ public class ApplicantBuilder {
         institution = applicantToCopy.getInstitution();
         graduationYearMonth = applicantToCopy.getGraduationYearMonth();
         course = applicantToCopy.getCourse();
+        status = applicantToCopy.getApplicationStatus();
         skills = new HashSet<>(applicantToCopy.getSkills());
     }
 
     /**
-     * Sets the {@code Name} of the {@code Person} that we are building.
+     * Sets the {@code Name} of the {@code Applicant} that we are building.
      */
     public ApplicantBuilder withName(String name) {
         this.name = new Name(name);
@@ -74,7 +78,7 @@ public class ApplicantBuilder {
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Applicant} that we are building.
      */
     public ApplicantBuilder withSkills(String ... skills) {
         this.skills = SampleDataUtil.getSkillSet(skills);
@@ -82,7 +86,7 @@ public class ApplicantBuilder {
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code Phone} of the {@code Applicant} that we are building.
      */
     public ApplicantBuilder withPhone(String phone) {
         this.phone = new Phone(phone);
@@ -90,7 +94,7 @@ public class ApplicantBuilder {
     }
 
     /**
-     * Sets the {@code Email} of the {@code Person} that we are building.
+     * Sets the {@code Email} of the {@code Applicant} that we are building.
      */
     public ApplicantBuilder withEmail(String email) {
         this.email = new Email(email);
@@ -98,7 +102,7 @@ public class ApplicantBuilder {
     }
 
     /**
-     * Sets the {@code Grade} of the {@code Person} that we are building.
+     * Sets the {@code Grade} of the {@code Applicant} that we are building.
      */
     public ApplicantBuilder withGrade(String grade) {
         this.grade = new Grade(grade);
@@ -106,14 +110,14 @@ public class ApplicantBuilder {
     }
 
     /**
-     * Sets the {@code Institution} of the {@code Person} that we are building.
+     * Sets the {@code Institution} of the {@code Applicant} that we are building.
      */
     public ApplicantBuilder withInstitution(String institution) {
         this.institution = new Institution(institution);
         return this;
     }
     /**
-     * Sets the {@code GraduationYearMonth} of the {@code Person} that we are building.
+     * Sets the {@code GraduationYearMonth} of the {@code Applicant} that we are building.
      */
     public ApplicantBuilder withGraduationYearMonth(String graduationYearMonth) {
         this.graduationYearMonth = new GraduationYearMonth(graduationYearMonth);
@@ -121,7 +125,15 @@ public class ApplicantBuilder {
     }
 
     /**
-     * Sets the {@code Course} of the {@code Person} that we are building.
+     * Sets the {@code ApplicationStatus} of the {@code Applicant} that we are building.
+     */
+    public ApplicantBuilder withApplicationStatus(String applicationStatus) {
+        this.status = new ApplicationStatus(applicationStatus);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Course} of the {@code Applicant} that we are building.
      */
     public ApplicantBuilder withCourse(String course) {
         this.course = new Course(course);
@@ -130,6 +142,6 @@ public class ApplicantBuilder {
 
 
     public Applicant build() {
-        return new Applicant(name, phone, email, grade, institution, course, graduationYearMonth, skills);
+        return new Applicant(name, phone, email, grade, institution, course, graduationYearMonth, status, skills);
     }
 }

--- a/src/test/java/seedu/intern/testutil/ApplicantUtil.java
+++ b/src/test/java/seedu/intern/testutil/ApplicantUtil.java
@@ -8,6 +8,7 @@ import static seedu.intern.logic.parser.CliSyntax.PREFIX_INSTITUTION;
 import static seedu.intern.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.intern.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.intern.logic.parser.CliSyntax.PREFIX_SKILL;
+import static seedu.intern.logic.parser.CliSyntax.PREFIX_STATUS;
 
 import java.util.Set;
 
@@ -55,6 +56,8 @@ public class ApplicantUtil {
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getGrade().ifPresent(grade -> sb.append(PREFIX_GRADE).append(grade.value).append(" "));
+        descriptor.getApplicationStatus()
+                .ifPresent(status -> sb.append(PREFIX_STATUS).append(status.value).append(" "));
         descriptor.getInstitution().ifPresent(institution -> sb.append(PREFIX_INSTITUTION)
                 .append(institution.value).append(" "));
         descriptor.getCourse().ifPresent(course -> sb.append(PREFIX_COURSE).append(course.value).append(" "));

--- a/src/test/java/seedu/intern/testutil/EditAllDescriptorBuilder.java
+++ b/src/test/java/seedu/intern/testutil/EditAllDescriptorBuilder.java
@@ -1,0 +1,43 @@
+package seedu.intern.testutil;
+
+import seedu.intern.logic.commands.EditAllCommand.EditAllDescriptor;
+import seedu.intern.model.applicant.Applicant;
+import seedu.intern.model.applicant.ApplicationStatus;
+
+/**
+ * A utility class to help with building EditPersonDescriptor objects.
+ */
+public class EditAllDescriptorBuilder {
+
+    private EditAllDescriptor descriptor;
+
+    public EditAllDescriptorBuilder() {
+        descriptor = new EditAllDescriptor();
+    }
+
+    public EditAllDescriptorBuilder(EditAllDescriptor descriptor) {
+        this.descriptor = new EditAllDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditAllDescriptor} with fields containing {@code applicant}'s relevant details
+     */
+    public EditAllDescriptorBuilder(Applicant applicant) {
+        descriptor = new EditAllDescriptor();
+        descriptor.setApplicationStatus(applicant.getApplicationStatus());;
+    }
+
+    /**
+     * Sets the {@code ApplicationStatus} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditAllDescriptorBuilder withApplicationStatus(String status) {
+        descriptor.setApplicationStatus(new ApplicationStatus(status));
+        return this;
+    }
+
+    public EditAllDescriptor build() {
+        return descriptor;
+    }
+
+
+}

--- a/src/test/java/seedu/intern/testutil/EditApplicantDescriptorBuilder.java
+++ b/src/test/java/seedu/intern/testutil/EditApplicantDescriptorBuilder.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import seedu.intern.logic.commands.EditCommand.EditApplicantDescriptor;
 import seedu.intern.model.applicant.Applicant;
+import seedu.intern.model.applicant.ApplicationStatus;
 import seedu.intern.model.applicant.Course;
 import seedu.intern.model.applicant.Email;
 import seedu.intern.model.applicant.Grade;
@@ -40,6 +41,7 @@ public class EditApplicantDescriptorBuilder {
         descriptor.setEmail(applicant.getEmail());
         descriptor.setGrade(applicant.getGrade());
         descriptor.setInstitution(applicant.getInstitution());
+        descriptor.setApplicationStatus(applicant.getApplicationStatus());
         descriptor.setGraduationYearMonth(applicant.getGraduationYearMonth());
         descriptor.setCourse(applicant.getCourse());
         descriptor.setSkills(applicant.getSkills());
@@ -82,6 +84,14 @@ public class EditApplicantDescriptorBuilder {
      */
     public EditApplicantDescriptorBuilder withInstitution(String institution) {
         descriptor.setInstitution(new Institution(institution));
+        return this;
+    }
+
+    /**
+     * Sets the {@code ApplicationStatus} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditApplicantDescriptorBuilder withApplicationStatus(String status) {
+        descriptor.setApplicationStatus(new ApplicationStatus(status));
         return this;
     }
 

--- a/src/test/java/seedu/intern/testutil/TypicalApplicants.java
+++ b/src/test/java/seedu/intern/testutil/TypicalApplicants.java
@@ -29,14 +29,14 @@ public class TypicalApplicants {
 
     public static final Applicant ALICE = new ApplicantBuilder().withName("Alice Pauline")
             .withEmail("alice@example.com").withPhone("94351253").withGrade("4.50")
-            .withInstitution("NUS").withCourse("Computer Science")
+            .withInstitution("NUS").withCourse("Computer Science").withApplicationStatus("REJECTED")
             .withGraduationYearMonth("12/2020").withSkills("friends").build();
-    public static final Applicant BENSON = new ApplicantBuilder().withName("Benson Meier")
+    public static final Applicant BENSON = new ApplicantBuilder().withName("Benson Meier").withApplicationStatus("INTERVIEWED")
             .withGrade("4.60").withInstitution("NTU").withCourse("Computer Engineering").withEmail("johnd@example.com")
             .withPhone("98765432").withGraduationYearMonth("06/2025").withSkills("owesMoney", "friends")
             .build();
     public static final Applicant CARL = new ApplicantBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withGrade("4.70").withInstitution("NTU").withCourse("Business and Accounting")
+            .withGrade("4.70").withInstitution("NTU").withCourse("Business and Accounting").withApplicationStatus("ACCEPTED")
             .withEmail("heinz@example.com").withGraduationYearMonth("12/2023").build();
     public static final Applicant DANIEL = new ApplicantBuilder().withName("Daniel Meier").withPhone("87652533")
             .withGrade("4.80").withInstitution("SMU").withEmail("cornelia@example.com")

--- a/src/test/java/seedu/intern/testutil/TypicalApplicants.java
+++ b/src/test/java/seedu/intern/testutil/TypicalApplicants.java
@@ -31,13 +31,14 @@ public class TypicalApplicants {
             .withEmail("alice@example.com").withPhone("94351253").withGrade("4.50")
             .withInstitution("NUS").withCourse("Computer Science").withApplicationStatus("REJECTED")
             .withGraduationYearMonth("12/2020").withSkills("friends").build();
-    public static final Applicant BENSON = new ApplicantBuilder().withName("Benson Meier").withApplicationStatus("INTERVIEWED")
+    public static final Applicant BENSON = new ApplicantBuilder().withName("Benson Meier")
             .withGrade("4.60").withInstitution("NTU").withCourse("Computer Engineering").withEmail("johnd@example.com")
             .withPhone("98765432").withGraduationYearMonth("06/2025").withSkills("owesMoney", "friends")
-            .build();
+            .withApplicationStatus("INTERVIEWED").build();
     public static final Applicant CARL = new ApplicantBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withGrade("4.70").withInstitution("NTU").withCourse("Business and Accounting").withApplicationStatus("ACCEPTED")
-            .withEmail("heinz@example.com").withGraduationYearMonth("12/2023").build();
+            .withGrade("4.70").withInstitution("NTU").withCourse("Business and Accounting")
+            .withApplicationStatus("ACCEPTED").withEmail("heinz@example.com").withGraduationYearMonth("12/2023")
+            .build();
     public static final Applicant DANIEL = new ApplicantBuilder().withName("Daniel Meier").withPhone("87652533")
             .withGrade("4.80").withInstitution("SMU").withEmail("cornelia@example.com")
             .withSkills("friends").withCourse("Accountancy").withGraduationYearMonth("01/2027").build();


### PR DESCRIPTION
## Add command `editAll`
Edits all currently displayed applicants

### notes
- Currently only supports status field, it does not make sense to edit all names
- `EditAllDescriptor` nested class created to replicate `EditCommand` logic
- Test cases not yet written

Closes #82, #86 