### PR TITLE
Reopen Selection fix

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -97,8 +97,9 @@ Format: `list`
 
 Edits an existing applicant, or all currently displayed applicants in Intern Watcher. 
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [g/GRADE] [i/INSTITUTION] [c/COURSE] [y/GRADUATION_YEAR_MONTH] [a/STATUS] [t/SKILL]…`
-`edit ALL [a/STATUS]`
+Format: 
+1. `edit INDEX] [n/NAME] [p/PHONE] [e/EMAIL] [g/GRADE] [i/INSTITUTION] [c/COURSE] [y/GRADUATION_YEAR_MONTH] [a/STATUS] [t/SKILL]…`
+2. `edit ALL [a/STATUS]`
 * If `INDEX` is specified, Edits the applicant at the specified `INDEX`. The index refers to the index number shown in the displayed applicant list. The index **must be a positive integer** 1, 2, 3, …+
 * If `ALL` is specified, edits all applicants currently displayed.
 * At least one of the optional fields must be provided.
@@ -110,6 +111,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [g/GRADE] [i/INSTITUTION] [c/CO
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st applicant to be `91234567` and `johndoe@example.com` respectively.
 *  `edit 2 n/Betsy Crower s/` Edits the name of the 2nd applicant to be `Betsy Crower` and clears all existing skills.
+*  `edit ALL a/ACCEPTED` Edits all currently displayed applicants to have the `ACCEPTED` Application Status.
 
 ### Locating applicants by name: `find`
 

--- a/docs/diagrams/EditActivityDiagram.puml
+++ b/docs/diagrams/EditActivityDiagram.puml
@@ -1,0 +1,20 @@
+@startuml
+start
+:User executes edit command;
+
+'Since the beta syntax does not support placing the condition outside the
+'diamond we place it as the true branch instead.
+
+if () then ([index provided])
+    :get applicant to edit;
+    :create edited applicant;
+    :update model with edited applicant;
+else ([all flag provided])
+    :get all displayed applicants;
+    while () is ([has displayed applicant not yet edited])
+        :create edited applicant;
+        :update model with edited applicant;
+    endwhile ([all displayed applicants edited])
+endif
+stop
+@enduml

--- a/docs/diagrams/EditAllSequence.puml
+++ b/docs/diagrams/EditAllSequence.puml
@@ -1,0 +1,92 @@
+@startuml
+!include style.puml
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":InternWatcherParser" as InternWatcherParser LOGIC_COLOR
+participant ":EditCommandParser" as EditCommandParser LOGIC_COLOR
+participant ":EditCommand" as EditCommand LOGIC_COLOR
+participant ":Selection" as Selection LOGIC_COLOR
+participant ":CommandResult" as CommandResult LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant ":Model" as Model MODEL_COLOR
+end box
+
+[-> LogicManager : execute("edit ALL a/ ACCEPTED")
+activate LogicManager
+
+LogicManager -> InternWatcherParser : parseCommand("edit ALL a/ ACCEPTED")
+activate InternWatcherParser
+
+create EditCommandParser
+InternWatcherParser -> EditCommandParser
+activate EditCommandParser
+
+EditCommandParser --> InternWatcherParser
+deactivate EditCommandParser
+
+InternWatcherParser -> EditCommandParser : parse("ALL")
+activate EditCommandParser
+
+create Selection
+EditCommandParser -> Selection
+activate Selection
+
+Selection --> EditCommandParser : d
+deactivate Selection
+
+create EditCommand
+EditCommandParser -> EditCommand
+activate EditCommand
+
+EditCommand --> EditCommandParser : d
+deactivate EditCommand
+
+EditCommandParser --> InternWatcherParser : d
+deactivate EditCommandParser
+'Hidden arrow to position the destroy marker below the end of the activation bar.
+EditCommandParser -[hidden]-> InternWatcherParser
+destroy EditCommandParser
+
+InternWatcherParser --> LogicManager : d
+deactivate InternWatcherParser
+
+LogicManager -> EditCommand : execute()
+activate EditCommand
+
+EditCommand -> Selection : hasIndex()
+activate Selection
+
+Selection -> EditCommand : d
+deactivate Selection
+
+loop for all applicants displayed
+EditCommand -> EditCommand : createEditedApplicant(applicant)
+activate EditCommand
+
+
+EditCommand --> EditCommand : d
+deactivate EditCommand
+
+EditCommand -> Model : setApplicant(applicant, editedApplicant)
+activate Model
+
+Model --> EditCommand : d
+deactivate Model
+end
+
+create CommandResult
+EditCommand -> CommandResult
+activate CommandResult
+
+CommandResult --> EditCommand
+deactivate CommandResult
+
+EditCommand --> LogicManager : result
+deactivate EditCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml

--- a/src/main/java/seedu/intern/commons/core/selection/Selection.java
+++ b/src/main/java/seedu/intern/commons/core/selection/Selection.java
@@ -2,13 +2,13 @@ package seedu.intern.commons.core.selection;
 
 public class Selection {
     private static final String MESSAGE_MISSING_INDEX = "Selection does not contain an Index.";
-    private static final String MESSAGE_MISSING_FLAG = "Selection does not contain an Extra Condition Flag.";
+    private static final String MESSAGE_MISSING_FLAG = "Selection does not contain an ALL Flag.";
     private final Index index;
-    private final Boolean isExtraCondition;
+    private final Boolean isAllSelected;
 
-    private Selection(Index index, Boolean isExtraCondition) {
+    private Selection(Index index, Boolean isAllSelected) {
         this.index = index;
-        this.isExtraCondition = isExtraCondition;
+        this.isAllSelected = isAllSelected;
     }
 
     public Index getIndex() {
@@ -31,32 +31,33 @@ public class Selection {
         }
     }
 
-    public boolean getExtraConditionFlag() {
-        if (hasExtraConditionFlag()) {
-            return isExtraCondition;
-        } else {
+    /**
+     * Returns true if ALL flag has been set by the user.
+     */
+    public boolean checkAllSelected() {
+        if (!hasAllSelectFlag()) {
             throw new NullPointerException(MESSAGE_MISSING_FLAG);
         }
+        // isAllSelected should not be false, as constructors are private.
+        assert this.isAllSelected;
+
+        return isAllSelected;
     }
 
     public boolean hasIndex() {
         return this.index != null;
     }
 
-    public boolean hasExtraConditionFlag() {
-        return this.isExtraCondition != null;
+    public boolean hasAllSelectFlag() {
+        return this.isAllSelected != null;
     }
 
-    public static Selection fromExtraConditionFlag(boolean flag) {
-        return new Selection(null, flag);
+    public static Selection fromAllFlag() {
+        return new Selection(null, true);
     }
 
     public static Selection fromIndex(Index index) {
         return new Selection(index, null);
-    }
-
-    public static Selection fromIndexAndToggle(Index index, boolean isExtraCondition) {
-        return new Selection(index, isExtraCondition);
     }
 
     @Override
@@ -72,14 +73,14 @@ public class Selection {
         Selection otherSelection = (Selection) other;
 
         if (this.hasIndex() != otherSelection.hasIndex()
-                || this.hasExtraConditionFlag() != otherSelection.hasExtraConditionFlag()) {
+                || this.hasAllSelectFlag() != otherSelection.hasAllSelectFlag()) {
             return false;
         }
 
         if (this.hasIndex() && this.getIndexOneBased() != otherSelection.getIndexOneBased()) {
             return false;
-        } else if (this.hasExtraConditionFlag()
-                && this.getExtraConditionFlag() != otherSelection.getExtraConditionFlag()) {
+        } else if (this.hasAllSelectFlag()
+                && this.checkAllSelected() != otherSelection.checkAllSelected()) {
             return false;
         } else {
             return true;

--- a/src/main/java/seedu/intern/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/intern/logic/commands/DeleteCommand.java
@@ -42,7 +42,7 @@ public class DeleteCommand extends Command {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
-        if (targetSelection.hasExtraConditionFlag()) {
+        if (targetSelection.hasAllSelectFlag() && targetSelection.checkAllSelected()) {
             int length = lastShownList.size();
             for (int i = 0; i < length; i++) {
                 Applicant applicantToDelete = lastShownList.get(0);

--- a/src/main/java/seedu/intern/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/intern/logic/commands/EditCommand.java
@@ -83,12 +83,25 @@ public class EditCommand extends Command {
     }
 
     /**
+     * Public constructor for {@code EditCommand}.
      * @param selection of the applicant(s) in the filtered applicant list to edit
      * @param editApplicantDescriptor details to edit the applicant with
      */
     public EditCommand(Selection selection, EditApplicantDescriptor editApplicantDescriptor) {
         requireNonNull(selection);
         requireNonNull(editApplicantDescriptor);
+
+        // editApplicant Descriptor should only contain ApplicationStatus if All flag is present
+        assert(!selection.hasAllSelectFlag()
+                || selection.checkAllSelected()
+                && editApplicantDescriptor.getName().isEmpty()
+                && editApplicantDescriptor.getCourse().isEmpty()
+                && editApplicantDescriptor.getEmail().isEmpty()
+                && editApplicantDescriptor.getGrade().isEmpty()
+                && editApplicantDescriptor.getGraduationYearMonth().isEmpty()
+                && editApplicantDescriptor.getInstitution().isEmpty()
+                && editApplicantDescriptor.getSkills().isEmpty()
+                && editApplicantDescriptor.getPhone().isEmpty());
 
         this.selection = selection;
         this.editApplicantDescriptor = new EditApplicantDescriptor(editApplicantDescriptor);
@@ -116,7 +129,7 @@ public class EditCommand extends Command {
             model.commitInternWatcher();
             return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedApplicant));
         } else {
-            if (!selection.getExtraConditionFlag()) {
+            if (!selection.checkAllSelected()) {
                 throw new CommandException(Messages.MESSAGE_UNEXPECTED_FLAG);
             }
 

--- a/src/main/java/seedu/intern/logic/commands/ViewCommand.java
+++ b/src/main/java/seedu/intern/logic/commands/ViewCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import seedu.intern.commons.core.Messages;
-import seedu.intern.commons.core.selection.Selection;
+import seedu.intern.commons.core.selection.Index;
 import seedu.intern.logic.commands.exceptions.CommandException;
 import seedu.intern.model.Model;
 import seedu.intern.model.applicant.Applicant;
@@ -25,10 +25,15 @@ public class ViewCommand extends Command {
 
     public static final String MESSAGE_VIEW_PERSON_SUCCESS = "Displayed Applicant details: %1$s";
 
-    private final Selection targetSelection;
+    private final Index targetIndex;
+    private final Boolean toggle;
 
-    public ViewCommand(Selection targetSelection) {
-        this.targetSelection = targetSelection;
+    /**
+     * User can view applicant details in Intern Watcher.
+     */
+    public ViewCommand(Index index, Boolean toggle) {
+        this.targetIndex = index;
+        this.toggle = toggle;
     }
 
     @Override
@@ -36,17 +41,17 @@ public class ViewCommand extends Command {
         requireNonNull(model);
         List<Applicant> lastShownList = model.getFilteredPersonList();
 
-        if (targetSelection.hasIndex()) {
-            if (targetSelection.getIndexZeroBased() >= lastShownList.size()) {
+        if (targetIndex != null) {
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
-        if (targetSelection.hasExtraConditionFlag()) {
-            Applicant applicantToView = lastShownList.get(targetSelection.getIndexZeroBased());
+        if (toggle) {
+            Applicant applicantToView = lastShownList.get(targetIndex.getZeroBased());
             model.displayApplicant(applicantToView, true);
             return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, applicantToView), false, false, true);
         } else {
-            Applicant applicantToView = lastShownList.get(targetSelection.getIndexZeroBased());
+            Applicant applicantToView = lastShownList.get(targetIndex.getZeroBased());
             model.displayApplicant(applicantToView, false);
             return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, applicantToView), false, false, true);
         }
@@ -56,6 +61,6 @@ public class ViewCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ViewCommand // instanceof handles nulls
-                && targetSelection.equals(((ViewCommand) other).targetSelection)); // state check
+                && targetIndex.equals(((ViewCommand) other).targetIndex)); // state check
     }
 }

--- a/src/main/java/seedu/intern/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/intern/logic/parser/EditCommandParser.java
@@ -57,7 +57,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
-        if (selection.hasExtraConditionFlag() && (argMultimap.getValue(PREFIX_NAME).isPresent()
+        if (selection.hasAllSelectFlag() && (argMultimap.getValue(PREFIX_NAME).isPresent()
                 || argMultimap.getValue(PREFIX_PHONE).isPresent()
                 || argMultimap.getValue(PREFIX_COURSE).isPresent()
                 || argMultimap.getValue(PREFIX_EMAIL).isPresent()

--- a/src/main/java/seedu/intern/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/intern/logic/parser/ParserUtil.java
@@ -2,7 +2,6 @@ package seedu.intern.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.intern.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.intern.logic.parser.CliSyntax.FLAG_ALL;
 import static seedu.intern.logic.parser.CliSyntax.FLAG_TOGGLE;
 
 import java.util.Arrays;
@@ -11,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javafx.util.Pair;
 import seedu.intern.commons.core.selection.Index;
 import seedu.intern.commons.core.selection.Selection;
 import seedu.intern.commons.util.StringUtil;
@@ -63,7 +63,7 @@ public class ParserUtil {
         }
 
         if (StringUtil.isAll(trimmedSelection)) {
-            return Selection.fromExtraConditionFlag(trimmedSelection.equals(FLAG_ALL));
+            return Selection.fromAllFlag();
         } else {
             return Selection.fromIndex(Index.fromOneBased(Integer.parseInt(trimmedSelection)));
         }
@@ -76,7 +76,7 @@ public class ParserUtil {
      * trimmed.
      * @throws ParseException if the specified selection is invalid.
      */
-    public static Selection parseView(String selection) throws ParseException {
+    public static Pair<Index, Boolean> parseView(String selection) throws ParseException {
         String [] trimmedSelection = selection.trim().split(" ");
         if (trimmedSelection.length > 2) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
@@ -94,10 +94,11 @@ public class ParserUtil {
         }
 
         if (trimmedSelection.length == 2) {
-            return Selection.fromIndexAndToggle(Index.fromOneBased(Integer.parseInt(trimmedSelection[0])),
+            return new Pair<>(Index.fromOneBased(Integer.parseInt(trimmedSelection[0])),
                     trimmedSelection[1].equals(FLAG_TOGGLE));
         } else {
-            return Selection.fromIndex(Index.fromOneBased(Integer.parseInt(trimmedSelection[0])));
+            return new Pair<>(Index.fromOneBased(Integer.parseInt(trimmedSelection[0])),
+                    null);
         }
     }
 
@@ -110,7 +111,7 @@ public class ParserUtil {
     @Deprecated
     public static Index parseDelete(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
-        if (trimmedIndex.equals("all")) {
+        if (trimmedIndex.equals("ALL")) {
             Index specialTag = Index.fromZeroBased(0);
             specialTag.setSpecialIndex();
             return specialTag;

--- a/src/main/java/seedu/intern/logic/parser/ViewCommandParser.java
+++ b/src/main/java/seedu/intern/logic/parser/ViewCommandParser.java
@@ -2,7 +2,8 @@ package seedu.intern.logic.parser;
 
 import static seedu.intern.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import seedu.intern.commons.core.selection.Selection;
+import javafx.util.Pair;
+import seedu.intern.commons.core.selection.Index;
 import seedu.intern.logic.commands.ViewCommand;
 import seedu.intern.logic.parser.exceptions.ParseException;
 
@@ -18,8 +19,8 @@ public class ViewCommandParser implements Parser<ViewCommand> {
      */
     public ViewCommand parse(String args) throws ParseException {
         try {
-            Selection selection = ParserUtil.parseView(args);
-            return new ViewCommand(selection);
+            Pair<Index, Boolean> parsed = ParserUtil.parseView(args);
+            return new ViewCommand(parsed.getKey(), parsed.getValue());
         } catch (ParseException pe) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/intern/model/applicant/ApplicationStatus.java
+++ b/src/main/java/seedu/intern/model/applicant/ApplicationStatus.java
@@ -9,7 +9,18 @@ import static seedu.intern.commons.util.AppUtil.checkArgument;
  */
 public class ApplicationStatus {
     public enum Status {
-        APPLIED, RECEIVED, SCHEDULED, INTERVIEWED, OFFERED, ACCEPTED, REJECTED
+        APPLIED("#FF0000"), RECEIVED("#FF0000"), SCHEDULED("#eb9e34"),
+        INTERVIEWED("#d1cc2a"), OFFERED("#358f21"), ACCEPTED("#76f25a"), REJECTED("#8c8c8c");
+
+        private final String colour;
+
+        private Status(String colour) {
+            this.colour = colour;
+        }
+
+        private Status() {
+            this.colour = "#3e7b91";
+        }
     }
 
     public static final Status DEFAULT_STATUS = Status.APPLIED;
@@ -56,6 +67,13 @@ public class ApplicationStatus {
      */
     public static boolean isValidStatus(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns the colour each application status should be set to.
+     */
+    public String getColour() {
+        return value.colour;
     }
 
     @Override

--- a/src/main/java/seedu/intern/ui/PersonCard.java
+++ b/src/main/java/seedu/intern/ui/PersonCard.java
@@ -51,6 +51,7 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(applicant.getPhone().value);
         email.setText(applicant.getEmail().value);
         status.setText(applicant.getApplicationStatus().value.toString());
+        status.setStyle(String.format("-fx-background-color: %s;", applicant.getApplicationStatus().getColour()));
     }
 
     @Override

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -1,26 +1,26 @@
 .background {
-    -fx-background-color: derive(#69B578, 20%);
-    background-color: #3A7D44; /* Used in the default.html file */
+    -fx-background-color: derive(#f2e9e4, 20%);
+    background-color: #c9ada7; /* Used in the default.html file */
 }
 
 .label {
     -fx-font-size: 11pt;
     -fx-font-family: "Open Sans Semibold";
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-opacity: 0.9;
 }
 
 .label-bright {
     -fx-font-size: 11pt;
     -fx-font-family: "Open Sans Semibold";
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-opacity: 1;
 }
 
 .label-header {
     -fx-font-size: 32pt;
     -fx-font-family: "Open Sans Light";
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-opacity: 1;
 }
 
@@ -32,7 +32,7 @@
 .tab-pane {
     -fx-padding: 0 0 0 1;
     -fx-tab-min-width: 54;
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 
 
@@ -51,29 +51,29 @@
 }
 
 .tab-pane .tab {
-    -fx-background-color: derive(#52995E, 30%);
+    -fx-background-color: derive(#decbc6, 30%);
 }
 
 .tab-pane .tab:selected {
-    -fx-background-color: #52995E;
+    -fx-background-color: #decbc6;
     -fx-border-color: transparent;
 }
 
 .tab .tab-label {
     -fx-alignment: CENTER;
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-font-size: 12px;
 }
 
 .tab:selected .tab-label {
     -fx-alignment: CENTER;
-    -fx-text-fill: #D0DB97;
+    -fx-text-fill: #4a4e69;
 }
 
 .table-view {
-    -fx-base: #69B578;
-    -fx-control-inner-background: #69B578;
-    -fx-background-color: #69B578;
+    -fx-base: #f2e9e4;
+    -fx-control-inner-background: #f2e9e4;
+    -fx-background-color: #f2e9e4;
     -fx-table-cell-border-color: transparent;
     -fx-table-header-border-color: transparent;
     -fx-padding: 5;
@@ -98,31 +98,31 @@
 .table-view .column-header .label {
     -fx-font-size: 20pt;
     -fx-font-family: "Open Sans Light";
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-alignment: center-left;
     -fx-opacity: 1;
 }
 
 .table-view:focused .table-row-cell:filled:focused:selected {
-    -fx-background-color: #D0DB97;
+    -fx-background-color: #4a4e69;
 }
 
 .split-pane:horizontal .split-pane-divider {
-    -fx-background-color: derive(#69B578, 20%);
+    -fx-background-color: derive(#f2e9e4, 20%);
     -fx-border-color: transparent transparent transparent #4d4d4d;
 }
 
 .split-pane {
     -fx-border-radius: 1;
     -fx-border-width: 1;
-    -fx-background-color: derive(#69B578, 20%);
+    -fx-background-color: derive(#f2e9e4, 20%);
 }
 
 .list-view {
     -fx-background-insets: 0;
     -fx-padding: 0;
-    -fx-background-color: derive(#69B578, 20%);
-    -fx-base: #69B578;
+    -fx-background-color: derive(#f2e9e4, 20%);
+    -fx-base: #f2e9e4;
 }
 
 .list-cell {
@@ -132,57 +132,57 @@
 }
 
 .list-cell:filled:even {
-    -fx-background-color: #3A7D44;
+    -fx-background-color: #c9ada7;
 }
 
 .list-cell:filled:odd {
-    -fx-background-color: #254D32;
+    -fx-background-color: #decbc6;
 }
 
 .list-cell:filled:selected {
-    -fx-background-color: #52995E;
+    -fx-background-color: #9a8c98;
 }
 
 .list-cell:filled:selected #cardPane {
-    -fx-border-color: #3e7b91;
+    -fx-border-color: #22223b;
     -fx-border-width: 1;
 }
 
 .list-cell .label {
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 
 .cell_big_label {
     -fx-font-family: "Open Sans Semibold";
     -fx-font-size: 16px;
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 
 .cell_small_label {
     -fx-font-family: "Open Sans Regular";
     -fx-font-size: 13px;
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 
 .stack-pane {
-     -fx-background-color: derive(#69B578, 20%);
+     -fx-background-color: derive(#f2e9e4, 20%);
 }
 
 .pane-with-border {
-     -fx-background-color: derive(#69B578, 20%);
-     -fx-border-color: derive(#69B578, 10%);
+     -fx-background-color: derive(#f2e9e4, 20%);
+     -fx-border-color: derive(#f2e9e4, 10%);
      -fx-border-top-width: 1px;
 }
 
 .status-bar {
-    -fx-background-color: derive(#69B578, 30%);
+    -fx-background-color: derive(#f2e9e4, 30%);
 }
 
 .result-display {
     -fx-background-color: transparent;
     -fx-font-family: "Open Sans Light";
     -fx-font-size: 13pt;
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 
 .result-display .label {
@@ -191,47 +191,47 @@
 
 .status-bar .label {
     -fx-font-family: "Open Sans Light";
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-padding: 4px;
     -fx-pref-height: 30px;
 }
 
 .status-bar-with-border {
-    -fx-background-color: derive(#69B578, 30%);
-    -fx-border-color: derive(#69B578, 25%);
+    -fx-background-color: derive(#f2e9e4, 30%);
+    -fx-border-color: derive(#f2e9e4, 25%);
     -fx-border-width: 1px;
 }
 
 .status-bar-with-border .label {
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 
 .grid-pane {
-    -fx-background-color: derive(#69B578, 30%);
-    -fx-border-color: derive(#69B578, 30%);
+    -fx-background-color: derive(#f2e9e4, 30%);
+    -fx-border-color: derive(#f2e9e4, 30%);
     -fx-border-width: 1px;
 }
 
 .grid-pane .stack-pane {
-    -fx-background-color: derive(#69B578, 30%);
+    -fx-background-color: derive(#f2e9e4, 30%);
 }
 
 .context-menu {
-    -fx-background-color: derive(#69B578, 50%);
+    -fx-background-color: derive(#f2e9e4, 50%);
 }
 
 .context-menu .label {
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 
 .menu-bar {
-    -fx-background-color: derive(#69B578, 20%);
+    -fx-background-color: derive(#f2e9e4, 20%);
 }
 
 .menu-bar .label {
     -fx-font-size: 14pt;
     -fx-font-family: "Open Sans Light";
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-opacity: 0.9;
 }
 
@@ -249,24 +249,24 @@
     -fx-border-color: #e2e2e2;
     -fx-border-width: 2;
     -fx-background-radius: 0;
-    -fx-background-color: #69B578;
+    -fx-background-color: #f2e9e4;
     -fx-font-family: "Open Sans Regular";
     -fx-font-size: 11pt;
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-background-insets: 0 0 0 0, 0, 1, 2;
 }
 
 .button:hover {
-    -fx-background-color: #52995E;
+    -fx-background-color: #decbc6;
 }
 
 .button:pressed, .button:default:hover:pressed {
-  -fx-background-color: #FFFFFF;
-  -fx-text-fill: #69B578;
+  -fx-background-color: #22223b;
+  -fx-text-fill: #f2e9e4;
 }
 
 .button:focused {
-    -fx-border-color: #FFFFFF, #FFFFFF;
+    -fx-border-color: #22223b, #22223b;
     -fx-border-width: 1, 1;
     -fx-border-style: solid, segments(1, 1);
     -fx-border-radius: 0, 0;
@@ -275,50 +275,50 @@
 
 .button:disabled, .button:default:disabled {
     -fx-opacity: 0.4;
-    -fx-background-color: #69B578;
-    -fx-text-fill: #FFFFFF;
+    -fx-background-color: #f2e9e4;
+    -fx-text-fill: #22223b;
 }
 
 .button:default {
-    -fx-background-color: #D0DB97;
-    -fx-text-fill: #FFFFFF;
+    -fx-background-color: #4a4e69;
+    -fx-text-fill: #22223b;
 }
 
 .button:default:hover {
-    -fx-background-color: derive(#D0DB97, 30%);
+    -fx-background-color: derive(#4a4e69, 30%);
 }
 
 .dialog-pane {
-    -fx-background-color: #69B578;
+    -fx-background-color: #f2e9e4;
 }
 
 .dialog-pane > *.button-bar > *.container {
-    -fx-background-color: #69B578;
+    -fx-background-color: #f2e9e4;
 }
 
 .dialog-pane > *.label.content {
     -fx-font-size: 14px;
     -fx-font-weight: bold;
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 
 .dialog-pane:header *.header-panel {
-    -fx-background-color: derive(#69B578, 25%);
+    -fx-background-color: derive(#f2e9e4, 25%);
 }
 
 .dialog-pane:header *.header-panel *.label {
     -fx-font-size: 18px;
     -fx-font-style: italic;
-    -fx-fill: #FFFFFF;
-    -fx-text-fill: #FFFFFF;
+    -fx-fill: #22223b;
+    -fx-text-fill: #22223b;
 }
 
 .scroll-bar {
-    -fx-background-color: derive(#69B578, 20%);
+    -fx-background-color: derive(#f2e9e4, 20%);
 }
 
 .scroll-bar .thumb {
-    -fx-background-color: derive(#69B578, 50%);
+    -fx-background-color: derive(#f2e9e4, 50%);
     -fx-background-insets: 3;
 }
 
@@ -350,15 +350,15 @@
 }
 
 #commandTextField {
-    -fx-background-color: transparent #3A7D44 transparent #3A7D44;
+    -fx-background-color: transparent #c9ada7 transparent #c9ada7;
     -fx-background-insets: 0;
-    -fx-border-color: #3A7D44 #3A7D44 #FFFFFF #3A7D44;
+    -fx-border-color: #c9ada7 #c9ada7 #22223b #c9ada7;
     -fx-border-insets: 0;
     -fx-border-width: 1;
     -fx-font-family: "Open Sans Light";
     -fx-font-size: 13pt;
-    -fx-text-fill: #FFFFFF;
-    -fx-prompt-text-fill: #D0DB97;
+    -fx-text-fill: #22223b;
+    -fx-prompt-text-fill: #4a4e69;
 }
 
 #filterField, #personListPanel, #personWebpage {
@@ -366,7 +366,7 @@
 }
 
 #resultDisplay .content {
-    -fx-background-color: transparent, #3A7D44, transparent, #3A7D44;
+    -fx-background-color: transparent, #c9ada7, transparent, #c9ada7;
     -fx-background-radius: 0;
 }
 
@@ -376,7 +376,16 @@
 }
 
 #tags .label {
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
+    -fx-background-color: #3e7b91;
+    -fx-padding: 1 3 1 3;
+    -fx-border-radius: 2;
+    -fx-background-radius: 2;
+    -fx-font-size: 11;
+}
+
+#status .label {
+    -fx-text-fill: #22223b;
     -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
@@ -390,7 +399,7 @@
 }
 
 #skills .label {
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
     -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;
     -fx-border-radius: 2;
@@ -400,6 +409,6 @@
 
 .tab-pane {
     -fx-tab-min-width: 54;
-    -fx-text-fill: #FFFFFF;
+    -fx-text-fill: #22223b;
 }
 

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -5,7 +5,7 @@
 
 .list-cell:empty {
     /* Empty cells will not have alternating colours */
-    -fx-background: derive(#52995E, 20%);
+    -fx-background: derive(#decbc6, 20%);
 }
 
 .tag-selector {

--- a/src/test/java/seedu/intern/commons/core/selection/SelectionTest.java
+++ b/src/test/java/seedu/intern/commons/core/selection/SelectionTest.java
@@ -2,12 +2,26 @@ package seedu.intern.commons.core.selection;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.intern.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 public class SelectionTest {
+    @Test
+    public void createAllSelection() {
+        Selection selection = Selection.fromAllFlag();
+
+        // check no Index
+        assertFalse(selection.hasIndex());
+        assertThrows(NullPointerException.class, selection::getIndexOneBased);
+        assertThrows(NullPointerException.class, selection::getIndexZeroBased);
+
+        // check All flag present
+        assertTrue(selection.hasAllSelectFlag());
+        assertTrue(selection.checkAllSelected());
+    }
 
     @Test
     public void createOneBasedSelection() {
@@ -21,6 +35,10 @@ public class SelectionTest {
         // convert from one-based selection to zero-based selection
         assertEquals(0, Selection.fromIndex(Index.fromOneBased(1)).getIndexZeroBased());
         assertEquals(4, Selection.fromIndex(Index.fromOneBased(5)).getIndexZeroBased());
+
+        // Check All flag not present
+        assertFalse(Selection.fromIndex(Index.fromOneBased(1)).hasAllSelectFlag());
+        assertThrows(NullPointerException.class, () -> Selection.fromIndex(Index.fromOneBased(1)).checkAllSelected());
     }
 
     @Test
@@ -35,26 +53,43 @@ public class SelectionTest {
         // convert from zero-based selection to one-based selection
         assertEquals(1, Selection.fromIndex(Index.fromZeroBased(0)).getIndexOneBased());
         assertEquals(6, Selection.fromIndex(Index.fromZeroBased(5)).getIndexOneBased());
+
+        // Check All flag
+        assertFalse(Selection.fromIndex(Index.fromZeroBased(0)).hasAllSelectFlag());
+        assertThrows(NullPointerException.class, () -> Selection.fromIndex(Index.fromZeroBased(0)).checkAllSelected());
     }
 
     @Test
     public void equals() {
-        final Selection fifthPersonselection = Selection.fromIndex(Index.fromOneBased(5));
+        final Selection fifthPersonSelection = Selection.fromIndex(Index.fromOneBased(5));
+        final Selection allApplicantSelection = Selection.fromAllFlag();
 
         // same values -> returns true
-        assertTrue(fifthPersonselection.equals(Selection.fromIndex(Index.fromOneBased(5))));
-        assertTrue(fifthPersonselection.equals(Selection.fromIndex(Index.fromZeroBased(4))));
+        assertEquals(Selection.fromIndex(Index.fromOneBased(5)), fifthPersonSelection);
+        assertEquals(Selection.fromIndex(Index.fromZeroBased(4)), fifthPersonSelection);
 
         // same object -> returns true
-        assertTrue(fifthPersonselection.equals(fifthPersonselection));
+        assertEquals(fifthPersonSelection, fifthPersonSelection);
 
         // null -> returns false
-        assertFalse(fifthPersonselection.equals(null));
+        assertNotEquals(fifthPersonSelection, null);
 
         // different types -> returns false
-        assertFalse(fifthPersonselection.equals(5.0f));
+        assertFalse(fifthPersonSelection.equals(5.0f));
 
         // different selection -> returns false
-        assertFalse(fifthPersonselection.equals(Selection.fromIndex(Index.fromZeroBased(1))));
+        assertNotEquals(Selection.fromIndex(Index.fromZeroBased(1)), fifthPersonSelection);
+
+        // same values -> returns true
+        assertEquals(Selection.fromAllFlag(), allApplicantSelection);
+
+        // same object -> returns true
+        assertEquals(allApplicantSelection, allApplicantSelection);
+
+        // null -> returns false
+        assertNotEquals(allApplicantSelection, null);
+
+        // different types -> returns false
+        assertNotEquals(allApplicantSelection, Boolean.TRUE);
     }
 }

--- a/src/test/java/seedu/intern/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/intern/logic/commands/CommandTestUtil.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import seedu.intern.commons.core.selection.Index;
+import seedu.intern.commons.core.selection.Selection;
 import seedu.intern.logic.commands.exceptions.CommandException;
 import seedu.intern.model.InternWatcher;
 import seedu.intern.model.Model;
@@ -155,6 +156,20 @@ public class CommandTestUtil {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
 
         Applicant applicant = model.getFilteredPersonList().get(targetIndex.getZeroBased());
+        final String[] splitName = applicant.getName().fullName.split("\\s+");
+        model.updateFilteredApplicantList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the applicant at the given {@code targetIndex} in the
+     * {@code model}'s intern book.
+     */
+    public static void showSelectedApplicant(Model model, Selection targetSelection) {
+        assertTrue(targetSelection.getIndexZeroBased() < model.getFilteredPersonList().size());
+
+        Applicant applicant = model.getFilteredPersonList().get(targetSelection.getIndexZeroBased());
         final String[] splitName = applicant.getName().fullName.split("\\s+");
         model.updateFilteredApplicantList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 

--- a/src/test/java/seedu/intern/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/intern/logic/commands/EditCommandTest.java
@@ -7,17 +7,23 @@ import static seedu.intern.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_SKILL_JAVA;
+import static seedu.intern.logic.commands.CommandTestUtil.VALID_STATUS_AMY;
+import static seedu.intern.logic.commands.CommandTestUtil.VALID_STATUS_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.intern.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.intern.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.intern.logic.commands.CommandTestUtil.showSelectedApplicant;
+import static seedu.intern.testutil.Assert.assertThrows;
 import static seedu.intern.testutil.TypicalApplicants.getTypicalInternWatcher;
-import static seedu.intern.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static seedu.intern.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.intern.testutil.TypicalSelections.SELECTION_ALL;
+import static seedu.intern.testutil.TypicalSelections.SELECTION_FIRST_PERSON;
+import static seedu.intern.testutil.TypicalSelections.SELECTION_SECOND_PERSON;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.intern.commons.core.Messages;
 import seedu.intern.commons.core.selection.Index;
+import seedu.intern.commons.core.selection.Selection;
 import seedu.intern.logic.commands.EditCommand.EditApplicantDescriptor;
 import seedu.intern.model.InternWatcher;
 import seedu.intern.model.Model;
@@ -26,6 +32,7 @@ import seedu.intern.model.UserPrefs;
 import seedu.intern.model.applicant.Applicant;
 import seedu.intern.testutil.ApplicantBuilder;
 import seedu.intern.testutil.EditApplicantDescriptorBuilder;
+import seedu.intern.testutil.TypicalApplicants;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for EditCommand.
@@ -35,10 +42,18 @@ public class EditCommandTest {
     private Model model = new ModelManager(getTypicalInternWatcher(), new UserPrefs());
 
     @Test
+    public void execute_validAllSelectInvalidDescriptorUnfilteredList_failure() {
+        EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder()
+                .withName(VALID_NAME_BOB).build();
+
+        assertThrows(AssertionError.class, () -> new EditCommand(SELECTION_ALL, descriptor));
+    }
+
+    @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Applicant editedApplicant = new ApplicantBuilder().build();
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder(editedApplicant).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(SELECTION_FIRST_PERSON, descriptor);
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedApplicant);
 
@@ -49,9 +64,62 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_validAllSelectUnfilteredList_success() {
+        EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_BOB).build();
+        EditCommand editCommand = new EditCommand(SELECTION_ALL, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ALL_SUCCESS,
+                model.getFilteredPersonList().size(), model.getFilteredPersonList().size());
+
+        ModelManager expectedModel = new ModelManager();
+        for (Applicant applicant : TypicalApplicants.getTypicalApplicants()) {
+            ApplicantBuilder applicantBuilder = new ApplicantBuilder(applicant).withApplicationStatus(VALID_STATUS_BOB);
+            expectedModel.addApplicant(applicantBuilder.build());
+        }
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validAllSelectEmptyUnfilteredList_success() {
+        ModelManager emptyModel = new ModelManager();
+        EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_BOB).build();
+        EditCommand editCommand = new EditCommand(SELECTION_ALL, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ALL_SUCCESS, 0, 0);
+
+        ModelManager expectedModel = new ModelManager();
+        assertCommandSuccess(editCommand, emptyModel, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validAllSelectSingleFilteredList_success() {
+        Model expectedModel = new ModelManager(new InternWatcher(model.getInternWatcher()), new UserPrefs());
+        showPersonAtIndex(model, SELECTION_FIRST_PERSON.getIndex());
+        showPersonAtIndex(expectedModel, SELECTION_FIRST_PERSON.getIndex());
+
+        Applicant applicantToEdit = model.getFilteredPersonList().get(SELECTION_FIRST_PERSON.getIndexZeroBased());
+        EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_AMY).build();
+        EditCommand editCommand = new EditCommand(SELECTION_ALL, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ALL_SUCCESS,
+                model.getFilteredPersonList().size(), model.getFilteredPersonList().size());
+
+        Applicant editedApplicant = new ApplicantBuilder(applicantToEdit)
+                .withApplicationStatus(VALID_STATUS_AMY).build();
+        expectedModel.setApplicant(applicantToEdit, editedApplicant);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
-        Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
-        Applicant lastApplicant = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
+        Selection indexLastPerson = Selection.fromIndex(Index.fromOneBased(model.getFilteredPersonList().size()));
+        Applicant lastApplicant = model.getFilteredPersonList().get(indexLastPerson.getIndexZeroBased());
 
         ApplicantBuilder personInList = new ApplicantBuilder(lastApplicant);
         Applicant editedApplicant = personInList.withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
@@ -70,9 +138,9 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditApplicantDescriptor());
-        Applicant editedApplicant = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+    public void execute_noFieldSpecifiedIndexUnfilteredList_success() {
+        EditCommand editCommand = new EditCommand(SELECTION_FIRST_PERSON, new EditApplicantDescriptor());
+        Applicant editedApplicant = model.getFilteredPersonList().get(SELECTION_FIRST_PERSON.getIndexZeroBased());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedApplicant);
 
@@ -82,12 +150,26 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+    public void execute_noFieldSpecifiedAllFlagUnfilteredList_success() {
+        EditCommand editCommand = new EditCommand(SELECTION_ALL, new EditApplicantDescriptor());
 
-        Applicant applicantInFilteredList = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ALL_SUCCESS,
+                model.getFilteredPersonList().size(),
+                model.getFilteredPersonList().size());
+
+        Model expectedModel = new ModelManager(new InternWatcher(model.getInternWatcher()), new UserPrefs());
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showSelectedApplicant(model, SELECTION_FIRST_PERSON);
+
+        Applicant applicantInFilteredList = model.getFilteredPersonList()
+                .get(SELECTION_FIRST_PERSON.getIndexZeroBased());
         Applicant editedApplicant = new ApplicantBuilder(applicantInFilteredList).withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        EditCommand editCommand = new EditCommand(SELECTION_FIRST_PERSON,
                 new EditApplicantDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedApplicant);
@@ -100,30 +182,32 @@ public class EditCommandTest {
 
     @Test
     public void execute_duplicatePersonUnfilteredList_failure() {
-        Applicant firstApplicant = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Applicant firstApplicant = model.getFilteredPersonList().get(SELECTION_FIRST_PERSON.getIndexZeroBased());
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder(firstApplicant).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_PERSON, descriptor);
+        EditCommand editCommand = new EditCommand(SELECTION_SECOND_PERSON, descriptor);
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
     public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showSelectedApplicant(model, SELECTION_FIRST_PERSON);
 
         // edit applicant in filtered list into a duplicate in intern book
-        Applicant applicantInList = model.getInternWatcher().getPersonList().get(INDEX_SECOND_PERSON.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON,
+        Applicant applicantInList = model.getInternWatcher().getPersonList()
+                .get(SELECTION_SECOND_PERSON.getIndexZeroBased());
+        EditCommand editCommand = new EditCommand(SELECTION_FIRST_PERSON,
                 new EditApplicantDescriptorBuilder(applicantInList).build());
 
         assertCommandFailure(editCommand, model, EditCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
-    public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+    public void execute_invalidPersonSelectionUnfilteredList_failure() {
+        Selection outOfBoundSelection = Selection
+                .fromIndex(Index.fromOneBased(model.getFilteredPersonList().size() + 1));
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder().withName(VALID_NAME_BOB).build();
-        EditCommand editCommand = new EditCommand(outOfBoundIndex, descriptor);
+        EditCommand editCommand = new EditCommand(outOfBoundSelection, descriptor);
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
@@ -133,13 +217,13 @@ public class EditCommandTest {
      * but smaller than size of intern book
      */
     @Test
-    public void execute_invalidPersonIndexFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        Index outOfBoundIndex = INDEX_SECOND_PERSON;
-        // ensures that outOfBoundIndex is still in bounds of intern book list
-        assertTrue(outOfBoundIndex.getZeroBased() < model.getInternWatcher().getPersonList().size());
+    public void execute_invalidPersonSelectionFilteredList_failure() {
+        showSelectedApplicant(model, SELECTION_FIRST_PERSON);
+        Selection outOfBoundSelection = SELECTION_SECOND_PERSON;
+        // ensures that outOfBoundSelection is still in bounds of intern book list
+        assertTrue(outOfBoundSelection.getIndexZeroBased() < model.getInternWatcher().getPersonList().size());
 
-        EditCommand editCommand = new EditCommand(outOfBoundIndex,
+        EditCommand editCommand = new EditCommand(outOfBoundSelection,
                 new EditApplicantDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
         assertCommandFailure(editCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
@@ -147,11 +231,11 @@ public class EditCommandTest {
 
     @Test
     public void equals() {
-        final EditCommand standardCommand = new EditCommand(INDEX_FIRST_PERSON, DESC_AMY);
+        final EditCommand standardCommand = new EditCommand(SELECTION_FIRST_PERSON, DESC_AMY);
 
         // same values -> returns true
         EditApplicantDescriptor copyDescriptor = new EditApplicantDescriptor(DESC_AMY);
-        EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
+        EditCommand commandWithSameValues = new EditCommand(SELECTION_FIRST_PERSON, copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true
@@ -164,10 +248,10 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(new ClearCommand()));
 
         // different index -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_PERSON, DESC_AMY)));
+        assertFalse(standardCommand.equals(new EditCommand(SELECTION_SECOND_PERSON, DESC_AMY)));
 
         // different descriptor -> returns false
-        assertFalse(standardCommand.equals(new EditCommand(INDEX_FIRST_PERSON, DESC_BOB)));
+        assertFalse(standardCommand.equals(new EditCommand(SELECTION_FIRST_PERSON, DESC_BOB)));
     }
 
 }

--- a/src/test/java/seedu/intern/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/intern/logic/parser/EditCommandParserTest.java
@@ -12,6 +12,8 @@ import static seedu.intern.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.intern.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.SKILL_DESC_JAVA;
 import static seedu.intern.logic.commands.CommandTestUtil.SKILL_DESC_PYTHON;
+import static seedu.intern.logic.commands.CommandTestUtil.STATUS_DESC_AMY;
+import static seedu.intern.logic.commands.CommandTestUtil.STATUS_DESC_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_NAME_AMY;
@@ -19,16 +21,21 @@ import static seedu.intern.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_SKILL_JAVA;
 import static seedu.intern.logic.commands.CommandTestUtil.VALID_SKILL_PYTHON;
+import static seedu.intern.logic.commands.CommandTestUtil.VALID_STATUS_AMY;
+import static seedu.intern.logic.parser.CliSyntax.FLAG_ALL;
 import static seedu.intern.logic.parser.CliSyntax.PREFIX_SKILL;
 import static seedu.intern.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.intern.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.intern.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.intern.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.intern.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.intern.testutil.TypicalSelections.SELECTION_ALL;
+import static seedu.intern.testutil.TypicalSelections.SELECTION_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.intern.commons.core.selection.Index;
+import seedu.intern.commons.core.selection.Selection;
 import seedu.intern.logic.commands.EditCommand;
 import seedu.intern.logic.commands.EditCommand.EditApplicantDescriptor;
 import seedu.intern.model.applicant.Email;
@@ -45,6 +52,53 @@ public class EditCommandParserTest {
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
 
     private EditCommandParser parser = new EditCommandParser();
+
+    @Test
+    public void parse_allSelectMultipleRepeatedFields_acceptsLast() {
+        String userInput = FLAG_ALL + STATUS_DESC_BOB + STATUS_DESC_AMY;
+
+        EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_AMY)
+                .build();
+        EditCommand expectedCommand = new EditCommand(Selection.fromAllFlag(), descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validArgsInt_returnsEditCommand() {
+        EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_AMY)
+                .build();
+        assertParseSuccess(parser,
+                "1 " + STATUS_DESC_AMY,
+                new EditCommand(SELECTION_FIRST_PERSON, descriptor));
+    }
+
+    @Test
+    public void parse_validArgsAll_returnsEditCommand() {
+        EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder()
+                .withApplicationStatus(VALID_STATUS_AMY)
+                .build();
+        assertParseSuccess(parser,
+                FLAG_ALL + STATUS_DESC_AMY,
+                new EditCommand(SELECTION_ALL, descriptor));
+    }
+
+    @Test
+    public void parse_invalidArgsAll_returnsEditCommand() {
+        // lowercase should not be accepted
+        assertParseFailure(parser,
+                "all" + STATUS_DESC_AMY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser,
+                "a " + STATUS_DESC_AMY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+    }
 
     @Test
     public void parse_missingParts_failure() {
@@ -107,7 +161,7 @@ public class EditCommandParserTest {
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY)
                 .withSkills(VALID_SKILL_JAVA, VALID_SKILL_PYTHON).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -119,7 +173,7 @@ public class EditCommandParserTest {
 
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -130,25 +184,25 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_THIRD_PERSON;
         String userInput = targetIndex.getOneBased() + NAME_DESC_AMY;
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // phone
         userInput = targetIndex.getOneBased() + PHONE_DESC_AMY;
         descriptor = new EditApplicantDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // email
         userInput = targetIndex.getOneBased() + EMAIL_DESC_AMY;
         descriptor = new EditApplicantDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // SKILLs
         userInput = targetIndex.getOneBased() + SKILL_DESC_PYTHON;
         descriptor = new EditApplicantDescriptorBuilder().withSkills(VALID_SKILL_PYTHON).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -162,7 +216,7 @@ public class EditCommandParserTest {
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withSkills(VALID_SKILL_PYTHON, VALID_SKILL_JAVA)
                 .build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -173,7 +227,7 @@ public class EditCommandParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
         String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder().withPhone(VALID_PHONE_BOB).build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
@@ -181,7 +235,7 @@ public class EditCommandParserTest {
                 + PHONE_DESC_BOB;
         descriptor = new EditApplicantDescriptorBuilder().withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
+        expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -191,7 +245,7 @@ public class EditCommandParserTest {
         String userInput = targetIndex.getOneBased() + SKILL_EMPTY;
 
         EditApplicantDescriptor descriptor = new EditApplicantDescriptorBuilder().withSkills().build();
-        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        EditCommand expectedCommand = new EditCommand(Selection.fromIndex(targetIndex), descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }


### PR DESCRIPTION
### Changes made

- `Selection` constructor now includes assertions to verify that all flag does not co exist with `Index`
- `fromIndexAndToggle` function has been removed
- Tests added for `edit ALL`
- `ViewCommand` has been modified to use a `Pair<Index, Boolean>` to preserve code functionality as far as possible
    - A better solution might involve some kind of flag parser similar to `ArgumentTokenizer`
    - `Boolean` can be replaced with something that better shows the purpose of the toggle flag

Closes #125 